### PR TITLE
Ignore unknown output types

### DIFF
--- a/nbterm/cell.py
+++ b/nbterm/cell.py
@@ -40,6 +40,9 @@ def get_output_text_and_height(outputs: List[Dict[str, Any]], console: Console):
         elif output["output_type"] == "execute_result":
             text = "\n".join(output["data"].get("text/plain", ""))
             height += text.count("\n") or 1
+        else:
+            continue
+
         text_list.append(text)
     text_ansi = ANSI("".join(text_list))
     return text_ansi, height


### PR DESCRIPTION
nbterm failed when opening an existing notebook (see #19), because the notebook contained an unexpected output type. For this fix I chose to ignore it, your approach may vary, let me know.

Also, I wanted to add a test for this, but you don't seem to have a suite set up just yet. The existing suite mostly resembles snapshot testing, so I didn't want to attempt to solve two things in one PR.