### PR TITLE
Add vim-style j, k bindings for moving up and down cells

### DIFF
--- a/nbterm/key_bindings.py
+++ b/nbterm/key_bindings.py
@@ -67,7 +67,17 @@ class KeyBindings:
             self.quitting = False
             self.go_up()
 
+        @self.key_bindings.add("k", filter=command_mode)
+        def up(event):
+            self.quitting = False
+            self.go_up()
+
         @self.key_bindings.add("down", filter=command_mode)
+        def down(event):
+            self.quitting = False
+            self.go_down()
+
+        @self.key_bindings.add("j", filter=command_mode)
         def down(event):
             self.quitting = False
             self.go_down()


### PR DESCRIPTION
Awesome project!

This PR adds "j" and "k" as navigation alternatives to the arrow keys, bringing `nbterm` slightly closer to the standard keybindings for Jupyter notebooks.