### PR TITLE
Add a main to the package itself

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -1,0 +1,3 @@
+from .nbterm import cli
+
+cli()


### PR DESCRIPTION
I really like using this package, and I was wondering whether we could add a `__main__` to the package itself. This would allow people to run `python3.11 -m nbterm` similar to how that would be possible with `python3.11 -m pip ...`.

When you want to explicitly use a specific Python version, or don't have the `Scripts`/`bin` directory on your path this could offer a nice alternative.